### PR TITLE
Исправление логики работы patch

### DIFF
--- a/migrations/versions/660bb7891726_scopes.py
+++ b/migrations/versions/660bb7891726_scopes.py
@@ -5,6 +5,7 @@ Revises: 6a486347af93
 Create Date: 2023-03-16 14:38:26.163590
 
 """
+
 import sqlalchemy as sa
 from alembic import op
 

--- a/migrations/versions/6a486347af93_order.py
+++ b/migrations/versions/6a486347af93_order.py
@@ -5,6 +5,7 @@ Revises: 670f4caac7dd
 Create Date: 2023-02-11 10:18:11.179485
 
 """
+
 import sqlalchemy as sa
 from alembic import op
 

--- a/migrations/versions/d35e88f39f85_end-to-end_numbering_fix.py
+++ b/migrations/versions/d35e88f39f85_end-to-end_numbering_fix.py
@@ -5,6 +5,7 @@ Revises: 660bb7891726
 Create Date: 2023-04-09 11:28:59.326067
 
 """
+
 import operator
 
 import sqlalchemy as sa

--- a/migrations/versions/d6b21dcb2c75_enum_type_button_fix.py
+++ b/migrations/versions/d6b21dcb2c75_enum_type_button_fix.py
@@ -5,6 +5,7 @@ Revises: d35e88f39f85
 Create Date: 2023-04-11 14:21:54.007129
 
 """
+
 import sqlalchemy as sa
 from alembic import op
 

--- a/services_backend/routes/base.py
+++ b/services_backend/routes/base.py
@@ -18,7 +18,7 @@ app = FastAPI(
     description='Программный интерфейс управления списком сервисов в приложении Твой ФФ!',
     version=__version__,
     # Настраиваем интернет документацию
-    root_path=settings.ROOT_PATH if __version__ != 'dev' else '/',
+    root_path=settings.ROOT_PATH if __version__ != 'dev' else '',
     docs_url=None if __version__ != 'dev' else '/docs',
     redoc_url=None,
 )

--- a/services_backend/routes/button.py
+++ b/services_backend/routes/button.py
@@ -155,7 +155,11 @@ def update_button(
     query = db.session.query(Button).filter(Category.id == category_id).filter(Button.id == button_id)
     button = query.one_or_none()
     last_button = (
-        db.session.query(Button).filter(Category.id == category_id).filter(Button.category_id == category_id).order_by(Button.order.desc()).first()
+        db.session.query(Button)
+        .filter(Category.id == category_id)
+        .filter(Button.category_id == category_id)
+        .order_by(Button.order.desc())
+        .first()
     )
     category = db.session.query(Category).filter(Category.id == category_id).one_or_none()
 
@@ -177,9 +181,13 @@ def update_button(
         if button_inp.order < 1:
             raise HTTPException(status_code=400, detail="Order can`t be less than 1")
         if button.order > button_inp.order:
-            db.session.query(Button).filter(Category.id == category_id).filter(Button.order < button.order).update({"order": Button.order + 1})
+            db.session.query(Button).filter(Category.id == category_id).filter(Button.order < button.order).update(
+                {"order": Button.order + 1}
+            )
         elif button.order < button_inp.order:
-            db.session.query(Button).filter(Category.id == category_id).filter(Button.order > button.order).update({"order": Button.order - 1})
+            db.session.query(Button).filter(Category.id == category_id).filter(Button.order > button.order).update(
+                {"order": Button.order - 1}
+            )
 
     query.update(button_inp.dict(exclude_unset=True, exclude_none=True))
     db.session.flush()

--- a/services_backend/routes/button.py
+++ b/services_backend/routes/button.py
@@ -152,10 +152,10 @@ def update_button(
     Необходимые scopes: `services.button.update`
     """
     logger.info(f"User {user.get('id')} triggered create_category")
-    query = db.session.query(Button).filter(Button.id == button_id)
+    query = db.session.query(Button).filter(Category.id == category_id).filter(Button.id == button_id)
     button = query.one_or_none()
     last_button = (
-        db.session.query(Button).filter(Button.category_id == category_id).order_by(Button.order.desc()).first()
+        db.session.query(Button).filter(Category.id == category_id).filter(Button.category_id == category_id).order_by(Button.order.desc()).first()
     )
     category = db.session.query(Category).filter(Category.id == category_id).one_or_none()
 
@@ -177,9 +177,9 @@ def update_button(
         if button_inp.order < 1:
             raise HTTPException(status_code=400, detail="Order can`t be less than 1")
         if button.order > button_inp.order:
-            db.session.query(Button).filter(Button.order < button.order).update({"order": Button.order + 1})
+            db.session.query(Button).filter(Category.id == category_id).filter(Button.order < button.order).update({"order": Button.order + 1})
         elif button.order < button_inp.order:
-            db.session.query(Button).filter(Button.order > button.order).update({"order": Button.order - 1})
+            db.session.query(Button).filter(Category.id == category_id).filter(Button.order > button.order).update({"order": Button.order - 1})
 
     query.update(button_inp.dict(exclude_unset=True, exclude_none=True))
     db.session.flush()


### PR DESCRIPTION
## Изменения
Изменил логику работы фильтрации, при выполнении patch запроса для кнопок.

## Детали реализации
Добавил проверку по id категории, которой раньше не было. Из-за этого происходили дубли по полю order

## Check-List
<!-- После сохранения у следующих полей появятся галочки, которые нужно проставить мышкой -->
- [x] Вы проверили свой код перед отправкой запроса?
- [x] Вы написали тесты к реализованным функциям?
- [x] Вы не забыли применить форматирование `black` и `isort` для _Back-End_ или `Prettier` для _Front-End_?
