### PR TITLE
Fix is_hidden patch error

### DIFF
--- a/services_backend/routes/button.py
+++ b/services_backend/routes/button.py
@@ -244,7 +244,7 @@ def update_button(
         raise HTTPException(status_code=404, detail="Category does not exist")
     if not button:
         raise HTTPException(status_code=404, detail="Button does not exist")
-    if not any(button_inp.model_dump().values()):
+    if all(value is None for value in button_inp.model_dump().values()):
         raise HTTPException(status_code=400, detail="Empty schema")
     if button.category_id != category_id:
         raise HTTPException(status_code=404, detail="Button is not this category")

--- a/tests/api/button.py
+++ b/tests/api/button.py
@@ -291,6 +291,21 @@ def test_patch_to_hide_success(client, db_button, db_category):
     assert res.json()["view"] == "hidden"
 
 
+def test_patch_to_unhide_success(client, db_button, db_category):
+    body = {"is_hidden": True}
+    res = client.patch(f"/category/{db_category.id}/button/{db_button.id}", data=json.dumps(body))
+    assert res.status_code == status.HTTP_200_OK
+    res_body = res.json()
+    assert res_body["is_hidden"] == True
+    body["is_hidden"] = False
+    res = client.patch(f"/category/{db_category.id}/button/{db_button.id}", data=json.dumps(body))
+    assert res.status_code == status.HTTP_200_OK
+    res_body = res.json()
+    assert res_body["name"] == db_button.name
+    assert res_body["is_hidden"] == False
+    assert res_body["link"] == db_button.link
+
+
 def test_delete_hidden_success(client, dbsession, db_button, db_category):
     db_button.is_hidden = True
     dbsession.commit()


### PR DESCRIPTION
## Изменения
Исправлена ошибка, из-за которой при попытке сделать кнопку снова видимой без изменения каких-либо других полей выдавалась ошибка 400 Empty schema

## Детали реализации
Проверка на получение пустой схемы в patch button теперь производится через сравнивание каждого поля с None, а не через булевое значение каждого поля.

Также добавлен тест по данному изменению

## Check-List
<!-- После сохранения у следующих полей появятся галочки, которые нужно проставить мышкой -->
- [ ] Вы проверили свой код перед отправкой запроса?
- [ ] Вы написали тесты к реализованным функциям?
- [ ] Вы не забыли применить форматирование `black` и `isort` для _Back-End_ или `Prettier` для _Front-End_?
